### PR TITLE
Fix issue with spaces in createSelectWithConstraint

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1119,7 +1119,7 @@ class Builder
     protected function createSelectWithConstraint($name)
     {
         return [explode(':', $name)[0], function ($query) use ($name) {
-            $query->select(explode(',', explode(':', $name)[1]));
+            $query->select(array_map('trim',explode(',', explode(':', $name)[1])));
         }];
     }
 


### PR DESCRIPTION
When constraining a field using a with and specified fields such as
with('table:id,name')

if the user has spaces such as
with('table:id, name')
it would error. 

This is a fix for that.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
